### PR TITLE
Loads configuration overrides from config/packages

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -24,6 +24,7 @@ class Repository extends IlluminateRepository
 
 		try {
 			$this->loadConfigurationFiles($hint, $namespace);
+			$this->loadConfigurationFiles(base_path() . '/config/packages/' . $package, $namespace);
 		}
 		catch (\InvalidArgumentException $e) {
 			// config directory doesn't exist, ignore..


### PR DESCRIPTION
Hi there,

Thanks for the great little package here, especially since a lot of packages haven't caught up with L5 yet.

I found an issue using LaravelFivePackageBridges with packages with user overridable configs. Basically, the override files aren't being loaded. Here's tiny one line patch that fixes that.
