### PR TITLE
Changed deprecated bindShared to singleton for L5.2

### DIFF
--- a/src/ConfigServiceProvider.php
+++ b/src/ConfigServiceProvider.php
@@ -30,7 +30,7 @@ class ConfigServiceProvider extends ServiceProvider {
 	{
 		$configs = $this->app['config']->all();
 
-		$this->app->bindShared('config', function () use ($configs) {
+		$this->app->singleton('config', function () use ($configs) {
 			$config = new Repository($configs);
 			return $config;
 		});


### PR DESCRIPTION
Since 5.2 bindShared has been removed (depracated on 5.1)
This fixes the issue.
